### PR TITLE
Updating instructions for using dkms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,25 @@
+# Module name
 obj-m += ionopi.o
 
+# Object files
 ionopi-objs := module.o
 ionopi-objs += commons/commons.o
 ionopi-objs += gpio/gpio.o
 ionopi-objs += wiegand/wiegand.o
 ionopi-objs += atecc/atecc.o
 
+# Kernel build directory
+KDIR := /lib/modules/$(shell uname -r)/build
+
 all:
-	make -C /lib/modules/$(shell uname -r)/build/ M=$(PWD) modules
+	make -C $(KDIR) M=$(PWD) modules
 
 clean:
-	make -C /lib/modules/$(shell uname -r)/build/ M=$(PWD) clean
+	make -C $(KDIR) M=$(PWD) clean
 
 install:
-	sudo install -m 644 -c ionopi.ko /lib/modules/$(shell uname -r)
+	@echo "Installing ionopi.ko into /lib/modules/$(shell uname -r)/extra/"
+	sudo install -d /lib/modules/$(shell uname -r)/extra
+	sudo install -m 644 -c ionopi.ko /lib/modules/$(shell uname -r)/extra/
 	sudo depmod
+	@echo "Module installed. Load with: sudo modprobe ionopi"

--- a/README.md
+++ b/README.md
@@ -27,13 +27,30 @@ Clone this repo:
 
     git clone --depth 1 https://github.com/sfera-labs/iono-pi-kernel-module.git
 
-Make and install:
+Make and install, alternative 1: For this kernel only
+
+* As an alternative, the module can be automatically built whenever the kernel is upgraded. For this, please see section DKMS below.
 
     cd iono-pi-kernel-module
     make clean
     make
     sudo make install
-    
+
+Make and install, alternative 2: Using DKMS
+
+[DKMS|(https://en.wikipedia.org/wiki/Dynamic_Kernel_Module_Support) can be used to keep the module updated whenever the kernel is updated using apt upgrade.
+
+Note: 
+First, create a symlink to the source directory
+
+    sudo ln -s "$(pwd)" /usr/src/ionopi-1.24
+
+where "1.24" should correspond to the actual version. Then use the following commands to add, build and install the module:
+
+    sudo dkms add -m ionopi -v 1.24
+    sudo dkms build -m ionopi -v 1.24
+    sudo dkms install -m ionopi -v 1.24
+
 Compile the Device Tree and install it:
 
     dtc -@ -Hepapr -I dts -O dtb -o ionopi.dtbo ionopi.dts
@@ -59,6 +76,8 @@ and add your user to the group, e.g., for user "pi":
 Reboot:
 
     sudo reboot
+
+
 
 ## Usage
 

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,0 +1,18 @@
+PACKAGE_NAME="ionopi"
+PACKAGE_VERSION="1.24"
+
+# How to build and clean the module
+MAKE="make -C ${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build"
+CLEAN="make -C ${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build clean"
+
+# Name of the module (without .ko extension)
+BUILT_MODULE_NAME[0]="ionopi"
+
+# Where the .ko file will be located after build
+BUILT_MODULE_LOCATION="."
+
+# Where to install the module within /lib/modules/<kernel>
+DEST_MODULE_LOCATION[0]="/extra"
+
+# Automatically rebuild and install this module when kernels are updated
+AUTOINSTALL="yes"


### PR DESCRIPTION
Move the installation folder to /lib/modules/$(shell uname -r)/extra/
Update instructions for using dkms, to automatically build the module when the kernel is upgraded.